### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/_dev/js/utils.js
+++ b/_dev/js/utils.js
@@ -25,5 +25,5 @@
 
 $(document).on('click', '[data-role-collapse]', function (e) {
     let collapsedElId = $(e.target).attr('data-collapsed');
-    $(collapsedElId).slideToggle();
+    $.find(collapsedElId).slideToggle();
 });


### PR DESCRIPTION
Fixes [https://github.com/202ecommerce/braintreeofficial/security/code-scanning/1](https://github.com/202ecommerce/braintreeofficial/security/code-scanning/1)

To fix this issue, we should ensure that the value of `collapsedElId` is treated as a plain text string and not as HTML. This can be achieved by using jQuery's `$.find` method, which interprets the input as a CSS selector and not as HTML. This change will prevent any potential XSS attacks by ensuring that the input is not executed as JavaScript.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
